### PR TITLE
URL fix

### DIFF
--- a/courses/open-ed.md
+++ b/courses/open-ed.md
@@ -112,7 +112,7 @@ Illich, I. (1970, July 2). [Why We Must Abolish Schooling](http://ournature.org/
 
 Illich, I. (1971). [_Deschooling Society_]("http://www.preservenet.com/theory/Illich/Deschooling/intro.html"). Harper & Row. New York.
 
-Kelty, C. (2008). [_Two Bits: The Cultural Significance of Free Software_](http://twobits.net/read/). Duke University Press. Durham, N.C.
+Kelty, C. (2008). [_Two Bits: The Cultural Significance of Free Software_](http://twobits.net/pub/Kelty-TwoBits.pdf). Duke University Press. Durham, N.C.
 
 Kamenetz, A. (2011). the [Edupunks’ Guide to a DIY Education!](http://www.edupunksguide.org/) Bill and Melinda Gates Foundation.
 [website and ebook].


### PR DESCRIPTION
Looks like they revamped the linked site and clobbered the old url. You appear to only be able to view the pdf version or download the zipped html. What do you think about having a "readings" area in the repository that contains the full copies of such freely licensed works?
